### PR TITLE
Add local address

### DIFF
--- a/Resources/ViewController.xib
+++ b/Resources/ViewController.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +13,7 @@
                 <outlet property="addressTextField" destination="iEI-dR-qrR" id="cgl-XE-V5X"/>
                 <outlet property="averageBandwidthLabel" destination="e5b-56-8x8" id="zil-Fc-In3"/>
                 <outlet property="bandwidthLabel" destination="1Ge-NS-FsL" id="hcb-EM-Pyv"/>
+                <outlet property="localAddressTextField" destination="EZg-YT-Bj9" id="4cH-nd-kbz"/>
                 <outlet property="portTextField" destination="UuP-Gg-rxj" id="xaF-gW-M4T"/>
                 <outlet property="progressView" destination="kwN-wQ-4YP" id="B5c-5o-5QW"/>
                 <outlet property="streamsSlider" destination="Rbl-s2-lvT" id="eZZ-fH-5VP"/>
@@ -49,31 +51,31 @@
                             </segments>
                         </segmentedControl>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Streams" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5ja-gB-7dU">
-                            <rect key="frame" x="16" y="200" width="64" height="21"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Server address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UBO-fv-fDb">
-                            <rect key="frame" x="16" y="89" width="116" height="21"/>
+                            <rect key="frame" x="16" y="200" width="140" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Server port" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jxe-Q6-xVn">
-                            <rect key="frame" x="16" y="127" width="87" height="21"/>
+                            <rect key="frame" x="16" y="127" width="140" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iEI-dR-qrR">
-                            <rect key="frame" x="164" y="84" width="140" height="30"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Local address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7nx-15-3dy">
+                            <rect key="frame" x="16" y="90" width="140" height="21"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="EZg-YT-Bj9">
+                            <rect key="frame" x="164" y="84" width="140" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numbersAndPunctuation"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" textContentType="url"/>
                         </textField>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="5201" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UuP-Gg-rxj">
                             <rect key="frame" x="164" y="122" width="140" height="30"/>
@@ -82,14 +84,14 @@
                             <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad"/>
                         </textField>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transmit mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jjn-mt-4aI">
-                            <rect key="frame" x="16" y="164" width="115" height="21"/>
+                            <rect key="frame" x="16" y="164" width="140" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Test duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xm2-Zo-HtJ">
-                            <rect key="frame" x="16" y="236" width="101" height="21"/>
+                            <rect key="frame" x="16" y="236" width="140" height="21"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
@@ -122,12 +124,30 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Server address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UBO-fv-fDb">
+                            <rect key="frame" x="16" y="52" width="140" height="21"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iEI-dR-qrR">
+                            <rect key="frame" x="164" y="46" width="140" height="34"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" textContentType="url"/>
+                        </textField>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <point key="canvasLocation" x="33.333333333333336" y="90.401785714285708"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Source/Backend/IPFTestRunner.m
+++ b/Source/Backend/IPFTestRunner.m
@@ -100,7 +100,14 @@ static void vc_reporter_callback(struct iperf_test *test)
     }
   }
 
-  iperf_set_test_server_hostname(test, (char *)[configuration.hostname cStringUsingEncoding:NSASCIIStringEncoding]);
+  {
+    char *hostname = (char *)[configuration.hostname cStringUsingEncoding:NSASCIIStringEncoding];
+
+    if (hostname != NULL) {
+      iperf_set_test_server_hostname(test, hostname);
+    }
+  }
+
   iperf_set_test_server_port(test, (int)configuration.port);
   iperf_set_test_duration(test, (int)configuration.duration);
 

--- a/Source/Backend/NetUtilities.h
+++ b/Source/Backend/NetUtilities.h
@@ -1,0 +1,31 @@
+//
+//  NetUtilities.h
+//  iperf
+//
+//  Created by Andy Peterman on 12/2/22.
+//
+
+#ifndef NetUtilities_h
+#define NetUtilities_h
+
+#import <UIKit/UIKit.h>
+
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+
+@interface NetUtilities : NSObject
+
++(UITextField*)getBestAddr:(UITextField*)addr
+				 localAddr:(UITextField*)localAddr
+					  port:(int)port;
+
++ (void)showError:(NSString*)title
+		formatStr:(NSString*)formatStr
+		  message:(NSString*)message
+			 code:(NSInteger)code
+popViewController:(BOOL)popViewController;
+
+@end
+
+
+#endif /* NetUtilities_h */

--- a/Source/Backend/NetUtilities.m
+++ b/Source/Backend/NetUtilities.m
@@ -1,0 +1,363 @@
+//
+//  NetUtilities.m
+//  iperf
+//
+//  Created by Andy Peterman on 12/2/22.
+//
+
+#import "NetUtilities.h"
+
+#include <netdb.h>
+#include <sys/time.h>
+
+@implementation NetUtilities
+
+// getBestAddr
+// Determine which address is best
+// If a local address is given and it matches the local network, then use that
+// Otherwise, use the regular address
+// This also tests each address for validity and displays any errors
+// Returns nil if neither address is any good
+
++(UITextField*)getBestAddr:(UITextField*)addrField
+				 localAddr:(UITextField*)localAddrField
+					  port:(int)port
+{
+	NSString* addr = addrField.text;
+	NSString* localAddr = localAddrField.text;
+	UITextField* result = nil;
+	NSString* alertTitle = nil;
+	NSString* alertFormatStr = nil;
+	NSString* alertMessage = nil;
+	int error1 = 0, error2 = 0;
+
+	// First check for valid addresses
+
+	if (addr.length == 0 && localAddr.length == 0)
+	{
+		alertTitle = @"Configuration Error";
+		alertMessage = @"You must specify at least one address.";
+		goto exit;
+	}
+	
+	// Now check validity of the address by attempting to create an NSURL
+	
+	if (addr.length > 0 && [NSURL URLWithString:addr] == nil)
+	{
+		alertTitle = @"Address Error";
+		alertFormatStr = @"The address '%@' is not valid.";
+		alertMessage = addr;
+		goto exit;
+	}
+	
+	if (localAddr.length > 0 && [NSURL URLWithString:localAddr] == nil)
+	{
+		alertTitle = @"Local Address Error";
+		alertFormatStr = @"The address '%@' is not valid.";
+		alertMessage = localAddr;
+		goto exit;
+	}
+	
+	// If we have a local address, check that it matches our network and if so,
+	// see if the host is really there, using a timeout of 1 second for our local network
+
+	if (localAddr.length > 0 && [NetUtilities isIPAddressOnLocalNetwork:localAddr])
+	{
+		error1 = [NetUtilities isHostValid:localAddr port:port timeout:1];
+		
+		if (error1 == 0)
+			result = localAddrField;
+	}
+	
+	// If no valid local device, try our main host address and test it too
+	
+	if (result == nil && addr.length > 0)
+	{
+		error2 = [NetUtilities isHostValid:addr port:port timeout:5];
+		
+		if (error2 == 0)
+			result = addrField;
+	}
+	
+	// If neither address worked, show error
+	
+	if (result == nil)
+	{
+		if (error2 != 0)
+		{
+			alertTitle = @"Address Error";
+			alertMessage = addr;
+	}
+		
+		else if (error1 != 0)
+		{
+			alertTitle = @"Local Address Error";
+			alertMessage = localAddr;
+		}
+
+		alertFormatStr = @"The address '%@' is not responding.";
+		goto exit;
+	}
+
+exit:
+	if (alertMessage)
+	{
+		[NetUtilities showError:alertTitle
+		 formatStr:alertFormatStr
+		   message:alertMessage
+			  code:0 		// errorCode
+ popViewController:YES];
+	}
+	
+	return result;
+}
+	
+// isIPAddressOnLocalNetwork
+// Return YES if the specified address is on any active network interface.
+// We look at any of the "enN" interfaces, which should cover any ethernet or wifi connections
+
++(BOOL)isIPAddressOnLocalNetwork:(NSString*)testIpAddr
+{
+//	CFTimeInterval startTime = CACurrentMediaTime();
+
+	BOOL retVal = NO;
+	struct in_addr inAddr, ipAddr, netMask;
+	struct ifaddrs* interfaces = NULL;
+	struct ifaddrs* tempAddr = NULL;
+	
+	// First strip out port number if it's there
+	
+	NSUInteger index = [testIpAddr rangeOfString:@":"].location;
+	if (index != NSNotFound)
+		testIpAddr = [testIpAddr substringToIndex:index];
+	
+	// Now convert our address (only ip4 addresses here) to binary form
+	
+	if (inet_aton (testIpAddr.UTF8String, &inAddr) != 0)		// If 0, then failed
+	{
+		// Retrieve the current interfaces - returns 0 on success
+		
+		if (getifaddrs (&interfaces) == 0)
+		{
+			tempAddr = interfaces;
+			
+			while (tempAddr != NULL)
+			{
+				// Check if interface is any of the "enX" ones which would be in use
+				
+				if (tempAddr->ifa_addr->sa_family == AF_INET)
+				{
+					if (tempAddr->ifa_name[0] == 'e' && tempAddr->ifa_name[1] == 'n')
+					{
+						// Using the net mask, see if this ip is the same as input address
+						
+						ipAddr = (((struct sockaddr_in*)tempAddr->ifa_addr)->sin_addr);
+						netMask = (((struct sockaddr_in*)tempAddr->ifa_netmask)->sin_addr);
+
+						if ((inAddr.s_addr & netMask.s_addr) == (ipAddr.s_addr & netMask.s_addr))
+						{
+							retVal = YES;
+							break;
+						}
+					}
+				}
+				
+				tempAddr = tempAddr->ifa_next;
+			}
+			
+			freeifaddrs (interfaces);
+		}
+	}
+	
+//	CFTimeInterval endTime = CACurrentMediaTime();
+//	NSLog(@"isIPAddressOnLocalNetwork Runtime: %g usec", (endTime - startTime) * 1e6);
+
+	return retVal;
+}
+
+// isHostValid
+// Test to see if the host at addr/port is valid by attempting to open a
+// TCP connection to it.  A time error (ETIMEDOUT) is returned if no connection
+// can be made with timeout seconds.
+// This is done with low level socket type calls.
+// Returns 0 if successful or an positive errno type error if there's a problem or
+// possibly -1 if other errors occur.  Errors of 1000+ are from gethostbyname
+
++(int)isHostValid:(NSString*)addr port:(int)port timeout:(int)timeout;
+{
+	int result = 0;
+	int socketfd;
+	struct sockaddr_in serverAddr;
+	struct hostent* server;
+	struct timeval timeoutVal;
+	int options;
+
+	// Set up timeval
+	
+	timeoutVal.tv_sec = timeout;
+	timeoutVal.tv_usec = 0;
+	
+	// Create a socket point
+	
+	socketfd = socket (AF_INET, SOCK_STREAM, 0);
+
+	if (socketfd < 0)
+	{
+		result = -1;
+		goto exit;
+	}
+	
+	// Set socket to be non-blocking by setting its option via fcntl
+
+	if ((options = fcntl (socketfd, F_GETFL, NULL)) < 0)
+	{
+		result = errno;
+		goto exit;
+	}
+
+	if (fcntl (socketfd, F_SETFL, options | O_NONBLOCK) < 0)
+	{
+		result = errno;
+		goto exit;
+	}
+
+	// Set up our hostent for use by
+
+	server = gethostbyname (addr.UTF8String);
+
+	if (server == NULL)
+	{
+		result = 1000 + h_errno;
+		goto exit;
+	}
+
+	bzero ((char*) &serverAddr, sizeof(serverAddr));
+	serverAddr.sin_family = AF_INET;
+	bcopy ((char*)server->h_addr, (char*)&serverAddr.sin_addr.s_addr, server->h_length);
+	serverAddr.sin_port = htons (port);
+
+	// Now try to connect to the server, waiting until it connects (writable) or times out
+	
+	if ((result = connect (socketfd, (struct sockaddr*)&serverAddr, sizeof(serverAddr))) < 0)
+	{
+		if (errno == EINPROGRESS)		// This would be the normal condition
+		{
+			fd_set wait_set;
+
+			// Make file descriptor set with socket
+			
+			FD_ZERO (&wait_set);
+			FD_SET (socketfd, &wait_set);
+
+			// Wait for socket to be writable; return after given timeout
+			
+			result = select (socketfd + 1, NULL, &wait_set, NULL, &timeoutVal);
+
+			// Set our result based on select result
+			
+			if (result == 0)			// Timeout
+				result = ETIMEDOUT;
+			
+			else if (result < 0)		// Error
+				result = errno;
+			
+			else						// Positive number (probably 1) is success
+				result = 0;
+		}
+	}
+	
+	// Reset socket flags
+	
+	if (fcntl (socketfd, F_SETFL, options) < 0)
+	{
+		result = errno;
+		goto exit;
+	}
+
+	// If successful, check for errors in socket layer
+	
+	if (result == 0)
+	{
+		socklen_t len = sizeof (options);
+		
+		if (getsockopt (socketfd, SOL_SOCKET, SO_ERROR, &options, &len) < 0)
+		{
+			result = errno;
+			goto exit;
+		}
+
+		// There was an error
+		
+		if (options)
+		{
+			result = options;
+			goto exit;
+		}
+	}
+
+exit:
+	
+	if (socketfd > 0)
+		close (socketfd);
+	
+	return result;
+}
+
+//	showError
+//	Show an error alert.
+//	If formatStr is nil, then just use message for message/informative text.
+//	Otherwise, create a string using format string, message, and code.
+
++ (void)showError:(NSString*)title
+		formatStr:(NSString*)formatStr
+		  message:(NSString*)message
+			 code:(NSInteger)code
+popViewController:(BOOL)popViewController	// iOS only
+{
+	// For iOS, use UIAlertController, which requires the source UIViewController to present it
+
+	UIViewController* rootViewController = [NetUtilities rootViewController];
+
+	// If we have a format string, use that to create the message
+
+	if (formatStr)
+	{
+		message = [NSString stringWithFormat:formatStr, message, code];
+	}
+
+	UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
+																   message:message
+															preferredStyle:UIAlertControllerStyleAlert];
+
+	// Our single Dismiss action will optionaly pop the view controller
+
+	UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"Dismiss"
+													   style:UIAlertActionStyleCancel
+													 handler:^(UIAlertAction *action)
+	{
+		if (popViewController)
+			[rootViewController.navigationController popViewControllerAnimated:YES];
+	}];
+
+	[alert addAction:okAction];
+
+	// Use calculated view controller to present this
+
+	[rootViewController presentViewController:alert
+									 animated:YES
+								   completion:nil];
+}
+
++ (UIViewController *)rootViewController
+{
+	UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+	if([rootViewController isKindOfClass:[UINavigationController class]])
+		rootViewController = ((UINavigationController *)rootViewController).viewControllers.firstObject;
+	if([rootViewController isKindOfClass:[UITabBarController class]])
+		rootViewController = ((UITabBarController *)rootViewController).selectedViewController;
+	if (rootViewController.presentedViewController != nil)
+		rootViewController = rootViewController.presentedViewController;
+	return rootViewController;
+}
+
+@end

--- a/Source/UI/IPFTestRunnerViewController.h
+++ b/Source/UI/IPFTestRunnerViewController.h
@@ -3,6 +3,7 @@
 @interface IPFTestRunnerViewController : UIViewController
 
 @property (strong, nonatomic) IBOutlet UITextField *addressTextField;
+@property (strong, nonatomic) IBOutlet UITextField *localAddressTextField;
 @property (strong, nonatomic) IBOutlet UITextField *portTextField;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *transmitModeSlider;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *streamsSlider;

--- a/iperf.xcodeproj/project.pbxproj
+++ b/iperf.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		2BF577A81DCF748600F55EDC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577801DCF748600F55EDC /* AppDelegate.m */; };
 		2BF577BB1DCF748600F55EDC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577A41DCF748600F55EDC /* main.m */; };
 		2BF577BC1DCF748600F55EDC /* IPFTestRunnerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577A71DCF748600F55EDC /* IPFTestRunnerViewController.m */; };
+		516D0533293AC852007BCA57 /* NetUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 516D0532293AC852007BCA57 /* NetUtilities.m */; };
 		B635ABF7227C1E92001ABB44 /* IPFTestRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */; };
 		B6570E212353D5F800A8F791 /* iperf_time.c in Sources */ = {isa = PBXBuildFile; fileRef = B6570E1F2353D5F700A8F791 /* iperf_time.c */; };
 		B6570E222353D5F800A8F791 /* iperf_time.c in Sources */ = {isa = PBXBuildFile; fileRef = B6570E1F2353D5F700A8F791 /* iperf_time.c */; };
@@ -104,6 +105,8 @@
 		2BF577A41DCF748600F55EDC /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2BF577A61DCF748600F55EDC /* IPFTestRunnerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPFTestRunnerViewController.h; sourceTree = "<group>"; };
 		2BF577A71DCF748600F55EDC /* IPFTestRunnerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IPFTestRunnerViewController.m; sourceTree = "<group>"; };
+		516D0532293AC852007BCA57 /* NetUtilities.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; name = NetUtilities.m; path = Source/Backend/NetUtilities.m; sourceTree = SOURCE_ROOT; tabWidth = 4; };
+		516D0536293ACCD7007BCA57 /* NetUtilities.h */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = NetUtilities.h; sourceTree = "<group>"; tabWidth = 4; };
 		B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IPFTestRunner.m; sourceTree = "<group>"; };
 		B635ABF8227C1EA4001ABB44 /* IPFTestRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPFTestRunner.h; sourceTree = "<group>"; };
 		B6570E1F2353D5F700A8F791 /* iperf_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = iperf_time.c; sourceTree = "<group>"; };
@@ -270,6 +273,8 @@
 		B635ABF5227C1E6E001ABB44 /* Backend */ = {
 			isa = PBXGroup;
 			children = (
+				516D0536293ACCD7007BCA57 /* NetUtilities.h */,
+				516D0532293AC852007BCA57 /* NetUtilities.m */,
 				B635ABF8227C1EA4001ABB44 /* IPFTestRunner.h */,
 				B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */,
 				2BA8E15F22AD93FC001466C2 /* IPFTestRunnerConfigurationType.h */,
@@ -339,7 +344,7 @@
 				TargetAttributes = {
 					2B6855E61DCF72D60009ABFD = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = LW2ABE364X;
+						DevelopmentTeam = VFLA4XR9UZ;
 						ProvisioningStyle = Automatic;
 					};
 					B692F603227D907600BE7313 = {
@@ -434,6 +439,7 @@
 				2B87F6551DCF76B900AA24E7 /* iperf_client_api.c in Sources */,
 				B6A90E36227D6D3400E3981C /* IPFTestRunnerConfiguration.m in Sources */,
 				2B013306228B7B830088D77D /* IPFHelpViewController.m in Sources */,
+				516D0533293AC852007BCA57 /* NetUtilities.m in Sources */,
 				2B87F6611DCF76B900AA24E7 /* tcp_info.c in Sources */,
 				2B87F6631DCF76B900AA24E7 /* timer.c in Sources */,
 				2BF577A81DCF748600F55EDC /* AppDelegate.m in Sources */,
@@ -573,19 +579,16 @@
 		2B6855FF1DCF72D60009ABFD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					armv7s,
-				);
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_USE_OPTIMIZATION_PROFILE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LW2ABE364X;
+				DEVELOPMENT_TEAM = VFLA4XR9UZ;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.teapotapps.iperf;
+				PRODUCT_BUNDLE_IDENTIFIER = org.treehouse.iperf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -594,19 +597,16 @@
 		2B6856001DCF72D60009ABFD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					"$(ARCHS_STANDARD)",
-					armv7s,
-				);
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_USE_OPTIMIZATION_PROFILE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LW2ABE364X;
+				DEVELOPMENT_TEAM = VFLA4XR9UZ;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.teapotapps.iperf;
+				PRODUCT_BUNDLE_IDENTIFIER = org.treehouse.iperf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};

--- a/iperf.xcodeproj/project.pbxproj
+++ b/iperf.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		2BF577A81DCF748600F55EDC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577801DCF748600F55EDC /* AppDelegate.m */; };
 		2BF577BB1DCF748600F55EDC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577A41DCF748600F55EDC /* main.m */; };
 		2BF577BC1DCF748600F55EDC /* IPFTestRunnerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BF577A71DCF748600F55EDC /* IPFTestRunnerViewController.m */; };
-		516D0533293AC852007BCA57 /* NetUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 516D0532293AC852007BCA57 /* NetUtilities.m */; };
+		51F3153529BFAC4A00F27A8B /* NetUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F3153429BFAC4900F27A8B /* NetUtilities.m */; };
 		B635ABF7227C1E92001ABB44 /* IPFTestRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */; };
 		B6570E212353D5F800A8F791 /* iperf_time.c in Sources */ = {isa = PBXBuildFile; fileRef = B6570E1F2353D5F700A8F791 /* iperf_time.c */; };
 		B6570E222353D5F800A8F791 /* iperf_time.c in Sources */ = {isa = PBXBuildFile; fileRef = B6570E1F2353D5F700A8F791 /* iperf_time.c */; };
@@ -105,8 +105,8 @@
 		2BF577A41DCF748600F55EDC /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2BF577A61DCF748600F55EDC /* IPFTestRunnerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPFTestRunnerViewController.h; sourceTree = "<group>"; };
 		2BF577A71DCF748600F55EDC /* IPFTestRunnerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IPFTestRunnerViewController.m; sourceTree = "<group>"; };
-		516D0532293AC852007BCA57 /* NetUtilities.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; name = NetUtilities.m; path = Source/Backend/NetUtilities.m; sourceTree = SOURCE_ROOT; tabWidth = 4; };
-		516D0536293ACCD7007BCA57 /* NetUtilities.h */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = NetUtilities.h; sourceTree = "<group>"; tabWidth = 4; };
+		51F3153329BFAC4900F27A8B /* NetUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetUtilities.h; sourceTree = "<group>"; };
+		51F3153429BFAC4900F27A8B /* NetUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NetUtilities.m; sourceTree = "<group>"; };
 		B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IPFTestRunner.m; sourceTree = "<group>"; };
 		B635ABF8227C1EA4001ABB44 /* IPFTestRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPFTestRunner.h; sourceTree = "<group>"; };
 		B6570E1F2353D5F700A8F791 /* iperf_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = iperf_time.c; sourceTree = "<group>"; };
@@ -273,8 +273,8 @@
 		B635ABF5227C1E6E001ABB44 /* Backend */ = {
 			isa = PBXGroup;
 			children = (
-				516D0536293ACCD7007BCA57 /* NetUtilities.h */,
-				516D0532293AC852007BCA57 /* NetUtilities.m */,
+				51F3153329BFAC4900F27A8B /* NetUtilities.h */,
+				51F3153429BFAC4900F27A8B /* NetUtilities.m */,
 				B635ABF8227C1EA4001ABB44 /* IPFTestRunner.h */,
 				B635ABF6227C1E92001ABB44 /* IPFTestRunner.m */,
 				2BA8E15F22AD93FC001466C2 /* IPFTestRunnerConfigurationType.h */,
@@ -344,7 +344,7 @@
 				TargetAttributes = {
 					2B6855E61DCF72D60009ABFD = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = VFLA4XR9UZ;
+						DevelopmentTeam = LW2ABE364X;
 						ProvisioningStyle = Automatic;
 					};
 					B692F603227D907600BE7313 = {
@@ -439,7 +439,7 @@
 				2B87F6551DCF76B900AA24E7 /* iperf_client_api.c in Sources */,
 				B6A90E36227D6D3400E3981C /* IPFTestRunnerConfiguration.m in Sources */,
 				2B013306228B7B830088D77D /* IPFHelpViewController.m in Sources */,
-				516D0533293AC852007BCA57 /* NetUtilities.m in Sources */,
+				51F3153529BFAC4A00F27A8B /* NetUtilities.m in Sources */,
 				2B87F6611DCF76B900AA24E7 /* tcp_info.c in Sources */,
 				2B87F6631DCF76B900AA24E7 /* timer.c in Sources */,
 				2BF577A81DCF748600F55EDC /* AppDelegate.m in Sources */,
@@ -579,16 +579,19 @@
 		2B6855FF1DCF72D60009ABFD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_USE_OPTIMIZATION_PROFILE = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = VFLA4XR9UZ;
+				DEVELOPMENT_TEAM = LW2ABE364X;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = org.treehouse.iperf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teapotapps.iperf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -597,16 +600,19 @@
 		2B6856001DCF72D60009ABFD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_USE_OPTIMIZATION_PROFILE = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = VFLA4XR9UZ;
+				DEVELOPMENT_TEAM = LW2ABE364X;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = org.treehouse.iperf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.teapotapps.iperf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};


### PR DESCRIPTION
Add "Local address" field which will automatically be used if server is on local network.
This allows going outside of your local network without having to re-enter the server address
each time you leave and come back.

Note: Documentation will need to be updated to explain this change.

ViewController:
	Added "Local address" field
	Set address fields to URL content
	Tweaked layout so names don't get truncated
	
NetUtilities:
	Added NetUtilites.m/h which contain some useful tools from my library

IPFTestRunner:
	Fix so that iperf_set_test_server_hostname isn't called when hostname is nil
	
IPFTestRunnerViewController:
	Added localAddressTextField field to hold local address
	Added local address to be saved and restored in defaults
	Added call to [NetUtilities getBestAddr ...] to determine which address to use, which
		includes some testing to make sure the address is valid.  If error, return gracefully.
	Address that's used is set to bold while the test is underway
	